### PR TITLE
Align script/setup with config/database.yaml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -25,7 +25,7 @@ default: &default
 
 development:
   <<: *default
-  database: posse_development
+  database: posse_party_development
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.

--- a/script/setup
+++ b/script/setup
@@ -29,7 +29,7 @@ export PLAYWRIGHT_CLI_VERSION=$(bundle exec ruby -e 'require "playwright"; puts 
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn add -D "playwright@$PLAYWRIGHT_CLI_VERSION"
 yarn run playwright install chromium
 
-DEVELOPMENT_DB_EXISTS=$(psql -lqt | cut -d \| -f 1 | grep -w posse_development | wc -l)
+DEVELOPMENT_DB_EXISTS=$(psql -lqt | cut -d \| -f 1 | grep -w posse_party_development | wc -l)
 if [ "$DEVELOPMENT_DB_EXISTS" -eq 0 ]; then
   echo "Creating development and test databases."
   bin/rails db:create


### PR DESCRIPTION
This mismatch in the script made the migration not run properly, and therefore when you ran bin/dev after script/setup it would blow up. :)

But this is the before/after that led to the change. I opted for aligning with config since I assume that's what's currently used by those working on the party. :)

```shell
$ git grep posse_development
config/database.yml:  database: posse_development
$ git grep posse_party_development
script/setup:DEVELOPMENT_DB_EXISTS=$(psql -lqt | cut -d \| -f 1 | grep -w posse_party_development | wc -l)
```

This change doesn't fit with the checklist below so I'm gonna ignore it 😅 

---
Before requesting review, confirm:

- [ ] New or updated tests cover the change
- [ ] The full test suite passes locally with CI=true
- [x] The PR description explains the behavior change and how to reproduce it
