### PR TITLE
Add yarn install to setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -14,6 +14,7 @@ FileUtils.chdir APP_ROOT do
 
   puts "== Installing dependencies =="
   system("bundle check") || system!("bundle install")
+  system! "yarn install"
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")


### PR DESCRIPTION
Without this, `bin/setup` fails with `Error: Can't resolve '@tailwindcss/container-queries'