### PR TITLE
Fix missing LinkedIn title

### DIFF
--- a/app/lib/platforms/linkedin/publishes_post.rb
+++ b/app/lib/platforms/linkedin/publishes_post.rb
@@ -52,7 +52,7 @@ class Platforms::Linkedin
             {
               article: {
                 source: url,
-                title: crosspost_config.og_title.presence || crosspost_config.title.presence,
+                title: crosspost_config.og_title.presence || crosspost_config.title.presence || content.truncate(60),
                 description: crosspost_config.og_description.presence || crosspost_config.summary,
                 thumbnail: image_urn
               }.compact

--- a/test/support/vcr_cassettes/linkedin_take.yml
+++ b/test/support/vcr_cassettes/linkedin_take.yml
@@ -234,7 +234,8 @@ http_interactions:
       string: '{"author":"urn:li:person:someperson","commentary":"Been a fun couple
         of weeks touring more remote parts of Japan, and I''m happy to report I''ve
         now stayed at least one night in 46 of Japan''s 47 prefectures. I''m saving
-        the last—Hokkaido—for next year. RubyKaigiかな","visibility":"PUBLIC","distribution":{"feedDistribution":"MAIN_FEED","targetEntities":[],"thirdPartyDistributionChannels":[]},"lifecycleState":"PUBLISHED","content":{"article":{"source":"https://justin.searls.co/posts/all-the-pretty-prefectures/","description":"Been
+        the last—Hokkaido—for next year. RubyKaigiかな","visibility":"PUBLIC","distribution":{"feedDistribution":"MAIN_FEED","targetEntities":[],"thirdPartyDistributionChannels":[]},"lifecycleState":"PUBLISHED","content":{"article":{"source":"https://justin.searls.co/posts/all-the-pretty-prefectures/","title":"Been
+        a fun couple of weeks touring more remote parts of J...","description":"Been
         a fun couple of weeks touring more remote parts of Japan, and I''m happy to
         report I''ve now stayed at least one night in 46 of Japan''s 47 prefectures.
         I''m saving the last—Hokkaido—for next year. RubyKaigiかな https://justin.searls.co/posts/all-the-pretty-prefectures/","thumbnail":"urn:li:image:D5610AQEYzRR1C4dhFA"}}}'


### PR DESCRIPTION
Fix a regression in https://github.com/searlsco/posse_party/pull/14 by restoring the fallback title when no title is available.

Read this first:

- Every change must be tested thoroughly.
- For fixes, include two commits: one adding a failing test that demonstrates the bug, and the next making that test pass.
- Working code and great ideas are not a guarantee of merge. PRs may be closed without comment or review.

Before requesting review, confirm:

- [x] New or updated tests cover the change
- [x] The full test suite passes locally with CI=true
- [x] The PR description explains the behavior change and how to reproduce it
