### PR TITLE
workflows/ci: filter CI jobs to only run on `main` branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - main
   schedule:
     - cron: "0 14 * * *" # Runs at 14:00 UTC every day, which is 10:00 AM EDT
 


### PR DESCRIPTION
Otherwise, the `pull_request` and `push` workflows will both run on an open non-fork PR.

Read this first:

- Every change must be tested thoroughly.
- For fixes, include two commits: one adding a failing test that demonstrates the bug, and the next making that test pass.
- Working code and great ideas are not a guarantee of merge. PRs may be closed without comment or review.

Before requesting review, confirm:

- [x] New or updated tests cover the change
- [x] The full test suite passes locally with CI=true
- [x] The PR description explains the behavior change and how to reproduce it
