### PR TITLE
linkedin/publishes_post: truncate description.

### DIFF
--- a/app/lib/platforms/linkedin/publishes_post.rb
+++ b/app/lib/platforms/linkedin/publishes_post.rb
@@ -1,5 +1,8 @@
 class Platforms::Linkedin
   class PublishesPost
+    TITLE_MAX_LENGTH = 60
+    DESCRIPTION_MAX_LENGTH = 4084
+
     Result = Struct.new(:success?, :post_urn, :url, :message)
 
     def initialize
@@ -52,8 +55,8 @@ class Platforms::Linkedin
             {
               article: {
                 source: url,
-                title: crosspost_config.og_title.presence || crosspost_config.title.presence || content.truncate(60),
-                description: crosspost_config.og_description.presence || crosspost_config.summary,
+                title: crosspost_config.og_title.presence || crosspost_config.title.presence || content.truncate(TITLE_MAX_LENGTH),
+                description: crosspost_config.og_description.presence || crosspost_config.summary.truncate(DESCRIPTION_MAX_LENGTH),
                 thumbnail: image_urn
               }.compact
             }

--- a/test/lib/platforms/linkedin/publishes_post_test.rb
+++ b/test/lib/platforms/linkedin/publishes_post_test.rb
@@ -63,6 +63,8 @@ class Platforms::Linkedin::PublishesPostTest < ActiveSupport::TestCase
     api = Mocktail.of_next(Platforms::Linkedin::CallsLinkedinApi)
     subject = Platforms::Linkedin::PublishesPost.new
     content = "This is a long LinkedIn post body that should be truncated for the title."
+    title_limit = Platforms::Linkedin::PublishesPost::TITLE_MAX_LENGTH
+    assert content.length > title_limit
 
     crosspost_config = CrosspostConfig.new(
       url: "https://example.com/posts/456",
@@ -80,7 +82,7 @@ class Platforms::Linkedin::PublishesPostTest < ActiveSupport::TestCase
       image_urn: nil,
       url: crosspost_config.url
     )
-    assert_equal content.truncate(60), expected_body.dig(:content, :article, :title)
+    assert_equal content.truncate(title_limit), expected_body.dig(:content, :article, :title)
     assert_equal "A consistent description", expected_body.dig(:content, :article, :description)
 
     stubs {
@@ -102,6 +104,64 @@ class Platforms::Linkedin::PublishesPostTest < ActiveSupport::TestCase
       crosspost_config,
       access_token: "token",
       person_urn: "urn:li:person:def456",
+      image_urn: nil,
+      url: crosspost_config.url
+    )
+
+    assert result.success?
+    verify {
+      api.call(
+        method: :post,
+        path: "rest/posts",
+        body: expected_body,
+        access_token: "token"
+      )
+    }
+  end
+
+  def test_truncates_summary_when_it_exceeds_linkedin_limit
+    api = Mocktail.of_next(Platforms::Linkedin::CallsLinkedinApi)
+    subject = Platforms::Linkedin::PublishesPost.new
+    summary_limit = Platforms::Linkedin::PublishesPost::DESCRIPTION_MAX_LENGTH
+    long_summary = "a" * (summary_limit + 5)
+
+    crosspost_config = CrosspostConfig.new(
+      url: "https://example.com/posts/789",
+      title: "A Summary Truncation Title",
+      summary: long_summary,
+      og_title: nil,
+      og_description: nil
+    )
+
+    expected_body = subject.send(
+      :build_post_data,
+      "Post body",
+      crosspost_config,
+      person_urn: "urn:li:person:ghi789",
+      image_urn: nil,
+      url: crosspost_config.url
+    )
+    assert_equal long_summary.truncate(4084), expected_body.dig(:content, :article, :description)
+
+    stubs {
+      api.call(
+        method: :post,
+        path: "rest/posts",
+        body: expected_body,
+        access_token: "token"
+      )
+    }.with {
+      Platforms::Linkedin::CallsLinkedinApi::Result.new(
+        success?: true,
+        headers: {"x-restli-id" => "urn:li:share:789"}
+      )
+    }
+
+    result = subject.publish(
+      "Post body",
+      crosspost_config,
+      access_token: "token",
+      person_urn: "urn:li:person:ghi789",
       image_urn: nil,
       url: crosspost_config.url
     )


### PR DESCRIPTION
This truncates the crosspost summary description to the maximum length returned by LinkedIn's API response.

Read this first:

- Every change must be tested thoroughly.
- For fixes, include two commits: one adding a failing test that demonstrates the bug, and the next making that test pass.
- Working code and great ideas are not a guarantee of merge. PRs may be closed without comment or review.

Before requesting review, confirm:

- [x] New or updated tests cover the change
- [x] The full test suite passes locally with CI=true
- [x] The PR description explains the behavior change and how to reproduce it
