### PR TITLE
Accept Google Docs atom entry in feeds.

### DIFF
--- a/config/initializers/feedjira_ext.rb
+++ b/config/initializers/feedjira_ext.rb
@@ -12,6 +12,16 @@ class Feedjira::Parser::AtomEntry
   element :"posse:post", as: :syndication_config
 end
 
+class Feedjira::Parser::GoogleDocsAtomEntry
+  element :subtitle, as: :subtitle, with: {type: "text"}
+  element :subtitle, as: :subtitle, with: {type: nil}
+  element :email, as: :author_email
+
+  elements :link, as: :link_rels, value: :rel
+
+  element :"posse:post", as: :syndication_config
+end
+
 Feedjira.configure do |config|
   config.strip_whitespace = true
 end

--- a/test/lib/fetches_feed/persists_feed_test.rb
+++ b/test/lib/fetches_feed/persists_feed_test.rb
@@ -13,6 +13,37 @@ class FetchesFeed
       assert_equal "Feed contains multiple entries with the same id: https://example.com/interviews/dup", error.message
     end
 
+    def test_persists_google_docs_atom_entries
+      feed = New.create(Feed)
+
+      PersistsFeed.new.persist(
+        feed,
+        ParsesFeed.new.parse(<<~XML),
+          <feed xmlns="http://www.w3.org/2005/Atom" xmlns:posse="https://posseparty.com/2024/Feed">
+            <entry>
+              <title>In case you missed it in Homebrew 5.1.0 release notes: we’re doing a…</title>
+              <link href="https://docs.google.com/forms/d/e/1FAIpQLSeeNd7T0Zj9zOl8Y2MP1YITPk_qNUIP5knfCqSmOH2oB2O_UQ/viewform" rel="alternate" type="text/html" />
+              <link href="https://mikemcquaid.com/thoughts/20260313121433/" rel="related" type="text/html" />
+              <published>2026-03-13T12:14:33+00:00</published>
+              <updated>2026-03-13T12:14:33+00:00</updated>
+              <id>https://docs.google.com/forms/d/e/1FAIpQLSeeNd7T0Zj9zOl8Y2MP1YITPk_qNUIP5knfCqSmOH2oB2O_UQ/viewform</id>
+              <author>
+                <name>Mike McQuaid</name>
+                <email>mike@mikemcquaid.com</email>
+              </author>
+              <posse:post format="json"><![CDATA[{"title":"Homebrew User Survey"}]]></posse:post>
+            </entry>
+          </feed>
+        XML
+        etag_header: nil,
+        last_modified_header: nil
+      )
+
+      post = feed.posts.sole
+
+      assert_equal ["Homebrew User Survey", "https://mikemcquaid.com/thoughts/20260313121433/"], [post.title, post.related_url]
+    end
+
     def duplicate_id_feed
       <<~XML
         <feed xmlns="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
Super weird `feedjira` behaviour but needs specifically customised so it doesn't explode when someone uses a Google Docs entry in an atom feed.

Did red-green testing to verify the test replicated the exception we were seeing in production, did a copy-paste of my Atom feed entry and then got OpenAI to work on a minimal fix here which is adding another parser to the initialiser.

---

- [x] New or updated tests cover the change
- [x] The full test suite passes locally with CI=true
- [x] The PR description explains the behavior change and how to reproduce it
