### PR TITLE
Bump LinkedIn API version to 202605

### DIFF
--- a/app/lib/platforms/linkedin/calls_linkedin_api.rb
+++ b/app/lib/platforms/linkedin/calls_linkedin_api.rb
@@ -7,7 +7,7 @@ class Platforms::Linkedin
       options = {
         headers: {
           "Authorization" => "Bearer #{access_token}",
-          "LinkedIn-Version" => "202505",
+          "LinkedIn-Version" => "202605",
           "X-Restli-Protocol-Version" => "2.0.0"
         }
       }

--- a/test/support/vcr_cassettes/linkedin_parentheses_fix.yml
+++ b/test/support/vcr_cassettes/linkedin_parentheses_fix.yml
@@ -13,7 +13,7 @@ http_interactions:
       Authorization:
       - Bearer fakeaccesstoken
       Linkedin-Version:
-      - '202505'
+      - '202605'
       X-Restli-Protocol-Version:
       - 2.0.0
       Content-Type:

--- a/test/support/vcr_cassettes/linkedin_take.yml
+++ b/test/support/vcr_cassettes/linkedin_take.yml
@@ -57,7 +57,7 @@ http_interactions:
       Authorization:
       - Bearer sometoken
       Linkedin-Version:
-      - '202505'
+      - '202605'
       X-Restli-Protocol-Version:
       - 2.0.0
       Content-Type:
@@ -243,7 +243,7 @@ http_interactions:
       Authorization:
       - Bearer sometoken
       Linkedin-Version:
-      - '202505'
+      - '202605'
       X-Restli-Protocol-Version:
       - 2.0.0
       Content-Type:


### PR DESCRIPTION
The previous version has been disabled.

- [x] The full test suite passes locally with CI=true
- [x] The PR description explains the behavior change and how to reproduce it
