### PR TITLE
Fix broken license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you want to roll up your sleeves and modify POSSE Party, check out [DEVELOPME
 
 ## License
 
-POSSE Party is free to use for non-commercial purposes and is distributed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0/).
+POSSE Party is free to use for non-commercial purposes and is distributed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0).
 
 You can use, modify, self-host, and share POSSE Party for:
 


### PR DESCRIPTION
Hi there,

The license link in this project's README currently leads to a GitHub Pages 404. It seems to be because of the trailing slash in the link.

Removing the trailing slash seemed like an easy fix, but you could also reach out to the PolyForm team instead.

-- Sage